### PR TITLE
Vorgängig kontrollierte Briefe als `finished` markieren

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .idea/
 venv/
+temp/

--- a/data/letters/10020.xml
+++ b/data/letters/10020.xml
@@ -76,7 +76,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10090.xml
+++ b/data/letters/10090.xml
@@ -77,7 +77,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10204.xml
+++ b/data/letters/10204.xml
@@ -83,7 +83,7 @@
 				<language ident="de" usage="992">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10227.xml
+++ b/data/letters/10227.xml
@@ -81,7 +81,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10244.xml
+++ b/data/letters/10244.xml
@@ -79,7 +79,7 @@
 				<language ident="de" usage="983">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10261.xml
+++ b/data/letters/10261.xml
@@ -80,7 +80,7 @@
 				<language ident="de" usage="977">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10262.xml
+++ b/data/letters/10262.xml
@@ -80,7 +80,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10263.xml
+++ b/data/letters/10263.xml
@@ -85,7 +85,7 @@
 				<language ident="la" usage="993">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10286.xml
+++ b/data/letters/10286.xml
@@ -93,7 +93,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10398.xml
+++ b/data/letters/10398.xml
@@ -77,7 +77,7 @@
 				<language ident="de" usage="940">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10409.xml
+++ b/data/letters/10409.xml
@@ -108,7 +108,7 @@
 				<language ident="la" usage="898">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10431.xml
+++ b/data/letters/10431.xml
@@ -86,7 +86,7 @@
 				<language ident="la" usage="846">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10434.xml
+++ b/data/letters/10434.xml
@@ -83,7 +83,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10435.xml
+++ b/data/letters/10435.xml
@@ -89,7 +89,7 @@
 				<language ident="la" usage="532">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10449.xml
+++ b/data/letters/10449.xml
@@ -91,7 +91,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10469.xml
+++ b/data/letters/10469.xml
@@ -88,7 +88,7 @@
 				<language ident="de" usage="1000">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10480.xml
+++ b/data/letters/10480.xml
@@ -85,7 +85,7 @@
 				<language ident="de" usage="1000">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10546.xml
+++ b/data/letters/10546.xml
@@ -72,7 +72,7 @@
 				<language ident="de" usage="1000">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10616.xml
+++ b/data/letters/10616.xml
@@ -93,7 +93,7 @@
 				<language ident="de" usage="1000">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10679.xml
+++ b/data/letters/10679.xml
@@ -91,7 +91,7 @@
 				<language ident="de" usage="961">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10717.xml
+++ b/data/letters/10717.xml
@@ -85,7 +85,7 @@
 				<language ident="la" usage="987">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10723.xml
+++ b/data/letters/10723.xml
@@ -82,7 +82,7 @@
 				<language ident="de" usage="974">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10724.xml
+++ b/data/letters/10724.xml
@@ -76,7 +76,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10741.xml
+++ b/data/letters/10741.xml
@@ -89,7 +89,7 @@
 				<language ident="la" usage="977">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10747.xml
+++ b/data/letters/10747.xml
@@ -83,7 +83,7 @@
 				<language ident="la" usage="944">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10750.xml
+++ b/data/letters/10750.xml
@@ -79,7 +79,7 @@
 				<language ident="de" usage="1000">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10795.xml
+++ b/data/letters/10795.xml
@@ -93,7 +93,7 @@
 				<language ident="de" usage="991">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10862.xml
+++ b/data/letters/10862.xml
@@ -79,7 +79,7 @@
 				<language ident="de" usage="1000">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10890.xml
+++ b/data/letters/10890.xml
@@ -89,7 +89,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/10980.xml
+++ b/data/letters/10980.xml
@@ -83,7 +83,7 @@
 				<language ident="de" usage="978">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11015.xml
+++ b/data/letters/11015.xml
@@ -84,7 +84,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11041.xml
+++ b/data/letters/11041.xml
@@ -95,7 +95,7 @@
 				<language ident="la" usage="979">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11048.xml
+++ b/data/letters/11048.xml
@@ -72,7 +72,7 @@
 				<language ident="de" usage="1000">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11049.xml
+++ b/data/letters/11049.xml
@@ -90,7 +90,7 @@
 				<language ident="la" usage="947">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11102.xml
+++ b/data/letters/11102.xml
@@ -77,7 +77,7 @@
 				<language ident="de" usage="1000">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11128.xml
+++ b/data/letters/11128.xml
@@ -80,7 +80,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11129.xml
+++ b/data/letters/11129.xml
@@ -89,7 +89,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11157.xml
+++ b/data/letters/11157.xml
@@ -76,7 +76,7 @@
 				</correspContext>
 			</correspDesc>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11232.xml
+++ b/data/letters/11232.xml
@@ -89,7 +89,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11268.xml
+++ b/data/letters/11268.xml
@@ -83,7 +83,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11339.xml
+++ b/data/letters/11339.xml
@@ -89,7 +89,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11340.xml
+++ b/data/letters/11340.xml
@@ -86,7 +86,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11415.xml
+++ b/data/letters/11415.xml
@@ -86,7 +86,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11440.xml
+++ b/data/letters/11440.xml
@@ -93,7 +93,7 @@
 				<language ident="la" usage="995">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11473.xml
+++ b/data/letters/11473.xml
@@ -109,7 +109,7 @@
 				<language ident="la" usage="955">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11486.xml
+++ b/data/letters/11486.xml
@@ -76,7 +76,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11571.xml
+++ b/data/letters/11571.xml
@@ -99,7 +99,7 @@
 				<language ident="la" usage="980">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11573.xml
+++ b/data/letters/11573.xml
@@ -83,7 +83,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11595.xml
+++ b/data/letters/11595.xml
@@ -85,7 +85,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11853.xml
+++ b/data/letters/11853.xml
@@ -89,7 +89,7 @@
 				<language ident="de" usage="1000">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11958.xml
+++ b/data/letters/11958.xml
@@ -83,7 +83,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/11983.xml
+++ b/data/letters/11983.xml
@@ -95,7 +95,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12054.xml
+++ b/data/letters/12054.xml
@@ -123,7 +123,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12337.xml
+++ b/data/letters/12337.xml
@@ -119,7 +119,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12360.xml
+++ b/data/letters/12360.xml
@@ -136,7 +136,7 @@
 				<language ident="de" usage="514">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12425.xml
+++ b/data/letters/12425.xml
@@ -123,7 +123,7 @@
 				<language ident="de" usage="1000">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12455.xml
+++ b/data/letters/12455.xml
@@ -89,7 +89,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12459.xml
+++ b/data/letters/12459.xml
@@ -104,7 +104,7 @@
 				<language ident="la" usage="996">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12495.xml
+++ b/data/letters/12495.xml
@@ -102,7 +102,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12506.xml
+++ b/data/letters/12506.xml
@@ -147,7 +147,7 @@
 				<language ident="la" usage="999">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12556.xml
+++ b/data/letters/12556.xml
@@ -127,7 +127,7 @@
 				<language ident="la" usage="910">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12572.xml
+++ b/data/letters/12572.xml
@@ -181,7 +181,7 @@
 				<language ident="de" usage="1000">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12628.xml
+++ b/data/letters/12628.xml
@@ -170,7 +170,7 @@
 				<language ident="de" usage="979">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12634.xml
+++ b/data/letters/12634.xml
@@ -110,7 +110,7 @@
 				<language ident="de" usage="999">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12651.xml
+++ b/data/letters/12651.xml
@@ -112,7 +112,7 @@
 				<language ident="de" usage="989">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12663.xml
+++ b/data/letters/12663.xml
@@ -166,7 +166,7 @@
 				<language ident="de" usage="982">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12783.xml
+++ b/data/letters/12783.xml
@@ -108,7 +108,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12809.xml
+++ b/data/letters/12809.xml
@@ -215,7 +215,7 @@
 				<language ident="la" usage="997">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12858.xml
+++ b/data/letters/12858.xml
@@ -100,7 +100,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12862.xml
+++ b/data/letters/12862.xml
@@ -125,7 +125,7 @@
 				<language ident="de" usage="992">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>
@@ -180,7 +180,7 @@
 			</div>
 			<div xml:id="div7" corresp="regest7">
 				<p>
-					<s n="16" xml:lang="de" type="auto">Der <persName ref="p7706" cert="high">Granvella</persName><note xml:id="fn17" type="footnote" n="17"><persName ref="p7706" cert="high">Nicolas Perrenot, Herr von Granvelle</persName>, der <placeName	ref="513">Ulm</placeName> am 6. Februar verlassen hatte; s. <ref target="file12871">Nr. 2822</ref>, Anm. 10.</note> ryt in das <placeName ref="l631" cert="high">Burgund</placeName>.</s>
+					<s n="16" xml:lang="de" type="auto">Der <persName ref="p7706" cert="high">Granvella</persName><note xml:id="fn17" type="footnote" n="17"><persName ref="p7706" cert="high">Nicolas Perrenot, Herr von Granvelle</persName>, der <placeName ref="513">Ulm</placeName> am 6. Februar verlassen hatte; s. <ref target="file12871">Nr. 2822</ref>, Anm. 10.</note> ryt in das <placeName ref="l631" cert="high">Burgund</placeName>.</s>
 					<s n="17" xml:lang="de" type="auto">Ist zuͦ <placeName ref="l1318" cert="high">Stockach</placeName> fur gezogen.<note xml:id="fn18" type="footnote" n="18">Vgl. <ref target="file12861">Nr. 2812</ref>,50-54.</note></s>
 				</p>
 			</div>

--- a/data/letters/12902.xml
+++ b/data/letters/12902.xml
@@ -152,7 +152,7 @@
 				<language ident="de" usage="995">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12905.xml
+++ b/data/letters/12905.xml
@@ -107,7 +107,7 @@
 				<language ident="la" usage="966">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12907.xml
+++ b/data/letters/12907.xml
@@ -140,7 +140,7 @@
 				<language ident="de" usage="600">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12908.xml
+++ b/data/letters/12908.xml
@@ -133,7 +133,7 @@
 				<language ident="la" usage="988">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12927.xml
+++ b/data/letters/12927.xml
@@ -123,7 +123,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12929.xml
+++ b/data/letters/12929.xml
@@ -113,7 +113,7 @@
 				<language ident="la" usage="951">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12940.xml
+++ b/data/letters/12940.xml
@@ -159,7 +159,7 @@
 				<language ident="de" usage="984">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12941.xml
+++ b/data/letters/12941.xml
@@ -99,7 +99,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12970.xml
+++ b/data/letters/12970.xml
@@ -95,7 +95,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12977.xml
+++ b/data/letters/12977.xml
@@ -103,7 +103,7 @@
 				<language ident="de" usage="1000">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12978.xml
+++ b/data/letters/12978.xml
@@ -91,7 +91,7 @@
 				<language ident="de" usage="958">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/12982.xml
+++ b/data/letters/12982.xml
@@ -91,7 +91,7 @@
 				<language ident="de" usage="944">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/13040.xml
+++ b/data/letters/13040.xml
@@ -89,7 +89,7 @@
 				<language ident="la" usage="1000">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/13045.xml
+++ b/data/letters/13045.xml
@@ -137,7 +137,7 @@
 				<language ident="de" usage="738">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/13122.xml
+++ b/data/letters/13122.xml
@@ -138,7 +138,7 @@
 				<language ident="de" usage="1000">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/13131.xml
+++ b/data/letters/13131.xml
@@ -123,7 +123,7 @@
 				<language ident="la" usage="689">Latein</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/13134.xml
+++ b/data/letters/13134.xml
@@ -118,7 +118,7 @@
 				<language ident="de" usage="871">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/13135.xml
+++ b/data/letters/13135.xml
@@ -86,7 +86,7 @@
 				<language ident="de" usage="1000">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/data/letters/13148.xml
+++ b/data/letters/13148.xml
@@ -173,7 +173,7 @@
 				<language ident="de" usage="979">Deutsch</language>
 			</langUsage>
 		</profileDesc>
-		<revisionDesc status="untouched">
+		<revisionDesc status="finished">
 			<change>init</change>
 		</revisionDesc>
 	</teiHeader>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+certifi==2024.6.2
+charset-normalizer==3.3.2
+idna==3.7
+lxml==5.2.2
+requests==2.32.3
+urllib3==2.2.2


### PR DESCRIPTION
Martin hat die Named Entities bei einigen Briefen bereits vor der Citizen Science Kampagne kontrolliert. Dieser PR setzt das Status-Attribut für die Citizen Science Plattform entsprechend.