### PR TITLE
Brief 10139: Absendeort Zofingen, Zofinger Pfarrer entfernen

### DIFF
--- a/data/letters/10139.xml
+++ b/data/letters/10139.xml
@@ -61,12 +61,11 @@
 					<orgName ref="og50pl41" cert="high"/>
 					<orgName ref="og50pl468" cert="high"/>
 					<orgName ref="og50pl49" cert="high"/>
-					<placeName source="l41" cert="high"><orig>Bern</orig></placeName>
+					<placeName source="l582" cert="high"><orig>Zofingen</orig></placeName>
 					<date when="1532-07-09" cert="high"/>
 				</correspAction>
 				<correspAction type="received">
 					<orgName ref="og50pl587" cert="high"/>
-					<orgName ref="og50pl582" cert="high"/>
 					<placeName source="l587" cert="low"><orig>Zürich</orig></placeName>
 				</correspAction>
 				<correspContext>


### PR DESCRIPTION
Gemäss IRG ist der Absendeort Zofingen, die Zofinger Pfarrer dürfen aber nicht als Briefpartner aufgeführt sein.